### PR TITLE
add .ruby-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 .DS_Store
+.ruby-version
+.idea


### PR DESCRIPTION
just adding a bit to gitignore.
* `.idea` is from JetBrains' RubyMine
* `ruby-version` is to enable rbenv locally